### PR TITLE
"Mux is not a constructor" fix.

### DIFF
--- a/mux-api-server/main.js
+++ b/mux-api-server/main.js
@@ -1,7 +1,7 @@
 require("dotenv").config();
 const express = require("express");
 const bodyParser = require("body-parser");
-const Mux = require("@mux/mux-node");
+const Mux = require("@mux/mux-node").default;
 const { Video } = new Mux(
   process.env.MUX_TOKEN_ID,
   process.env.MUX_TOKEN_SECRET


### PR DESCRIPTION
recent Mux version does not export the default module. Do this instead 👇
> const Mux = require("@mux/mux-node").default;